### PR TITLE
Added Wagon blips and some other features.

### DIFF
--- a/client/MainPedSpawns.lua
+++ b/client/MainPedSpawns.lua
@@ -1,12 +1,18 @@
 --[[####################################################################################################################################]]
 ----------------------Handles the spawning of manager ped, setting draw3d text up, and opening menu------------------------------------------------------
 --[[####################################################################################################################################]]
-
+local npcs = {}
+local blips = {}
 --Manager Ped Spawn Setup 
 Citizen.CreateThread(function()
   local model = GetHashKey(Config.ManagerPedModel) --sets the npc model
   if Config.ManagerBlip == true then --if blip in config = true then if false this will not run, and will not make a blip
-    local blip = VORPutils.Blips:SetBlip(Config.Language.ManagerBlip, Config.ManagerBlipHash, 0.8, OilWagonTable.ManagerSpawn.x, OilWagonTable.ManagerSpawn.y, OilWagonTable.ManagerSpawn.z) --Creates a blip on the manager location set in config. Using vorp utils
+    local blip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, OilWagonTable.ManagerSpawn.x, OilWagonTable.ManagerSpawn.y, OilWagonTable.ManagerSpawn.z) -- This create a blip with a defualt blip hash we given
+    SetBlipSprite(blip, Config.ManagerBlipHash, 1) -- This sets the blip hash to the given in config.
+    SetBlipScale(blip, 0.8) --sets the blip scale
+    Citizen.InvokeNative(0x662D364ABF16DE2F, blip, joaat(Config.ManagerBlipColor)) --sets the blip color
+    Citizen.InvokeNative(0x9CB1A1623062F402, blip, Config.Language.ManagerBlip) -- Sets the blip Name
+    table.insert(blips, blip) --Store the blip in the blips table
   end
   modelload(model)
   local createdped = CreatePed(model, OilWagonTable.ManagerSpawn.x, OilWagonTable.ManagerSpawn.y, OilWagonTable.ManagerSpawn.z - 1, OilWagonTable.ManagerSpawn.h, false, true, true, true) --creates ped the minus one makes it so its standing on the ground not floating first boolean is for network. Disabled so only 1 ped shows per player
@@ -34,7 +40,12 @@ end)
 Citizen.CreateThread(function()
   local model = GetHashKey(Config.CriminalPedModel) --gets the models hash key
   if Config.CriminalPedBlip then --if config setting true then if false it wont run
-    local blip = VORPutils.Blips:SetBlip(Config.Language.CriminalPedBlip, Config.CrimBlipHash, 0.8, Config.CriminalPedSpawn.x, Config.CriminalPedSpawn.y, Config.CriminalPedSpawn.z) --Creates a blip on the manager location set in config. Using vorp utils
+  local blip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, Config.CriminalPedSpawn.x, Config.CriminalPedSpawn.y, Config.CriminalPedSpawn.z) -- This create a blip with a defualt blip hash we given
+  SetBlipSprite(blip, Config.CriminalBlipHash, 1) -- This sets the blip hash to the given in config.
+  SetBlipScale(blip, 0.8) --sets the blip scale
+  Citizen.InvokeNative(0x662D364ABF16DE2F, blip, joaat(Config.CriminalBlipColor)) --sets the blip color
+  Citizen.InvokeNative(0x9CB1A1623062F402, blip, Config.Language.CriminalPedBlip) -- Sets the blip Name
+  table.insert(blips, blip) --Store the blip in the blips table
   end
   modelload(model) --triggers the function to load the model
   local createdped = CreatePed(model, Config.CriminalPedSpawn.x, Config.CriminalPedSpawn.y, Config.CriminalPedSpawn.z - 1, Config.CriminalPedSpawn.h, false, true, true, true) --creates the ped at the location
@@ -52,5 +63,27 @@ Citizen.CreateThread(function()
         })
       end
     end
+  end
+end)
+
+-- Function to delete NPCs
+function DeleteNPCs()
+  for k, v in pairs(npcs) do
+      DeletePed(v)
+  end
+end
+
+-- Function to delete blips
+function DeleteBlips()
+  for k, v in pairs(blips) do
+      RemoveBlip(v)
+  end
+end
+
+-- Call the DeleteNPCs function when the resource stops
+AddEventHandler("onResourceStop", function(resource)
+  if resource == GetCurrentResourceName() then
+      DeleteNPCs()
+      DeleteBlips()
   end
 end)

--- a/client/MainWagonSpawn.lua
+++ b/client/MainWagonSpawn.lua
@@ -15,10 +15,18 @@ AddEventHandler('bcc:oil:PlayerWagonSpawn', function(wagon) --makes the event ha
   Createdwagon = CreateVehicle(wagon, sw.x, sw.y, sw.z, sw.h, true, true) --spawns the wagon
   Citizen.InvokeNative(0x77FF8D35EEC6BBC4, Createdwagon, 1, 0)
   TriggerEvent('bcc:oil:PlayerWagonDistFromSpawnCheck')
+  local wagonBlip = Citizen.InvokeNative(0x23F74C2FDA6E7C61, -1749618580, Createdwagon) -- Add wagon blip
+  SetBlipScale(wagonBlip, 0.8) --sets wagon blip scale
   if wagon == 'oilwagon02x' then --if variable = text then
+    SetBlipSprite(wagonBlip, Config.OilWagonBilpHash, 1) -- sets oil wagon blip icon
+    Citizen.InvokeNative(0x662D364ABF16DE2F, wagonBlip, joaat(Config.OilWagonBlipColor))  --Sets oil wagon blip color
+    Citizen.InvokeNative(0x9CB1A1623062F402, wagonBlip, Config.Language.OilWagonBlipName) -- Sets oil wagon blip name
     TriggerEvent('bcc-oil:WagonDeliveriesDeadCheck') --triggers dead check event from below(has to be triggered as an event triggering it as function would cause it not to run the function below)
     beginningstage() --triggers function
   elseif wagon == 'armysupplywagon' then --elseif variable = this then
+    SetBlipSprite(wagonBlip, Config.SupplyWagonBilpHash, 1) -- sets supply wagon blip icon
+    Citizen.InvokeNative(0x662D364ABF16DE2F, wagonBlip, joaat(Config.SupplyWagonBlipColor))  --Sets supply wagon blip color
+    Citizen.InvokeNative(0x9CB1A1623062F402, wagonBlip, Config.Language.SupplyWagonBlipName) -- Sets supply wagon blip name
     TriggerEvent('bcc-oil:WagonDeliveriesDeadCheck') --triggers the dead check event from below
     supplymissionbeginstage() --triggers function
   end

--- a/config.lua
+++ b/config.lua
@@ -8,7 +8,16 @@ Config.OilWagon = {price = 100, sellprice = 80} --Oil wagon model hash theres 2 
 Config.OilWagonFillTime = 10000 --time in ms it takes to fill the oil wagon aswell as unload when delivering oil
 Config.BasicOilDeliveryPay = 50 --This is the base pay rate for doing an oil mission (the payoutbonus in the Config.OilCompanyLevels will be added to this amount)
 Config.LevelIncreasePerDelivery = 1 --sets the amount your level increases per delivery mission
-Config.ManagerBlipHash = 'blip_mp_torch'
+--------------------- config player's wagon blip---------------------------
+Config.OilWagonBilpHash = 1612913921 --Set Oil Wagon blip icon using blip hashes (https://redlookup.com/blips)
+Config.OilWagonBlipColor = 'BLIP_MODIFIER_MP_COLOR_32' --Set Supply wagon blip color. you can find the colors you can use in the end of this config file
+Config.SupplyWagonBilpHash = 1612913921 --Set Supply Wagon blip icon using blip hashes (https://redlookup.com/blips)
+Config.SupplyWagonBlipColor = 'BLIP_MODIFIER_MP_COLOR_32' --Set Supply wagon blip color. you can find the colors you can use in the end of this config file
+------------------------ config company manager blip and criminal blip-------------------------
+Config.ManagerBlipHash = 1000514759
+Config.ManagerBlipColor = 'BLIP_MODIFIER_MP_COLOR_2'
+Config.CriminalBlipHash = 1000514759
+Config.CriminalBlipColor = 'BLIP_MODIFIER_MP_COLOR_2'
 
 -------------This is the levels, and what they pay-----------------------------------------
 --This level setup is for the entire oil company this will effect payout for basic jobs etc(You can add or remove levels as you please but there has to be atleast 1)
@@ -191,5 +200,41 @@ Config.Language = {
     RobOilCoBlip = 'Rob The Oil Company',
     RobberySuccess = 'You Robbed the oil company now flee!',
     PressGToLockPick = 'Press "G" To LockPick',
-    DefendAgainstAttackers = 'You are being attacked defend yourself!'
+    DefendAgainstAttackers = 'You are being attacked defend yourself!',
+    SupplyWagonBlipName = 'Supply Wagon', -- suply wagon blip name
+    OilWagonBlipName = 'Oil Wagon' -- oil wagon blip name
 }
+
+--[[--------BLIP_COLORS----------
+LIGHT_BLUE    = 'BLIP_MODIFIER_MP_COLOR_1',
+DARK_RED      = 'BLIP_MODIFIER_MP_COLOR_2',
+PURPLE        = 'BLIP_MODIFIER_MP_COLOR_3',
+ORANGE        = 'BLIP_MODIFIER_MP_COLOR_4',
+TEAL          = 'BLIP_MODIFIER_MP_COLOR_5',
+LIGHT_YELLOW  = 'BLIP_MODIFIER_MP_COLOR_6',
+PINK          = 'BLIP_MODIFIER_MP_COLOR_7',
+GREEN         = 'BLIP_MODIFIER_MP_COLOR_8',
+DARK_TEAL     = 'BLIP_MODIFIER_MP_COLOR_9',
+RED           = 'BLIP_MODIFIER_MP_COLOR_10',
+LIGHT_GREEN   = 'BLIP_MODIFIER_MP_COLOR_11',
+TEAL2         = 'BLIP_MODIFIER_MP_COLOR_12',
+BLUE          = 'BLIP_MODIFIER_MP_COLOR_13',
+DARK_PUPLE    = 'BLIP_MODIFIER_MP_COLOR_14',
+DARK_PINK     = 'BLIP_MODIFIER_MP_COLOR_15',
+DARK_DARK_RED = 'BLIP_MODIFIER_MP_COLOR_16',
+GRAY          = 'BLIP_MODIFIER_MP_COLOR_17',
+PINKISH       = 'BLIP_MODIFIER_MP_COLOR_18',
+YELLOW_GREEN  = 'BLIP_MODIFIER_MP_COLOR_19',
+DARK_GREEN    = 'BLIP_MODIFIER_MP_COLOR_20',
+BRIGHT_BLUE   = 'BLIP_MODIFIER_MP_COLOR_21',
+BRIGHT_PURPLE = 'BLIP_MODIFIER_MP_COLOR_22',
+YELLOW_ORANGE = 'BLIP_MODIFIER_MP_COLOR_23',
+BLUE2         = 'BLIP_MODIFIER_MP_COLOR_24',
+TEAL3         = 'BLIP_MODIFIER_MP_COLOR_25',
+TAN           = 'BLIP_MODIFIER_MP_COLOR_26',
+OFF_WHITE     = 'BLIP_MODIFIER_MP_COLOR_27',
+LIGHT_YELLOW2 = 'BLIP_MODIFIER_MP_COLOR_28',
+LIGHT_PINK    = 'BLIP_MODIFIER_MP_COLOR_29',
+LIGHT_RED     = 'BLIP_MODIFIER_MP_COLOR_30',
+LIGHT_YELLOW3 = 'BLIP_MODIFIER_MP_COLOR_31',
+WHITE         = 'BLIP_MODIFIER_MP_COLOR_32']]


### PR DESCRIPTION
- Added Wagon Blip option.
- Oil Wagon blip hash, blip color, and blip name can be changed in the config file.
- Supply wagon blip hash, blip color, and blip name can be changed in the config file.
- Manger blip hash and blip color can be changed in the config file.
- The criminal blip hash and blip color can be changed in the config file.
- Spawned Manger, Criminal NPC, and Blips will be deleted when the resource stops.